### PR TITLE
docs: form-sizing プロパティ記事に対する追記

### DIFF
--- a/articles/20231003-form-sizing-normal.md
+++ b/articles/20231003-form-sizing-normal.md
@@ -44,6 +44,12 @@ https://github.com/tkent-google/explainers/blob/main/form-sizing.md
 
 https://github.com/w3c/csswg-drafts/issues/7552
 
+# 2023.10.10 追記 `form-sizing: fixed | content`
+
+紹介したそばから `normal` → `fixed` 、 `auto` → `content` に変更されていました。([IRCログ](https://github.com/w3c/csswg-drafts/issues/7542#issuecomment-1747803316)) 次項のサンプルコードは`normal | auto` のままですが使い方自体は変更されていないようです。
+
+`form-sizing` ではなく `field-sizing` というプロパティ名への変更も提案されていてポジティブな流れなので、そのうちこれも変更されるかもしれません。テーマ通りいかにも時期尚早な紹介といったオチでした。:)
+
 # 本稿執筆時点で提案されている API
 
 以下のサンプルコードは [explainers/form-sizing.md at main · tkent-google/explainers](https://github.com/tkent-google/explainers/blob/main/form-sizing.md) からの引用です。


### PR DESCRIPTION
# Checks

## for Author

- [ ] タイトルの末尾に ` | Offers Tech Blog` がついている
- [ ] `publication_name: "overflow_offers"` が設定されている
- [ ] 記事の末尾に関連記事が載っている（任意）

## for Editor

- [ ] `published: true` が設定されている
- [ ] `published_at: yyyy-mm-dd 09:00` が設定されている